### PR TITLE
Prepare v0.8.0 release for HACS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A comprehensive Home Assistant integration for managing OpenWrt networks with ad
 - `rpcd` package installed (usually pre-installed)
 
 ### Home Assistant Requirements
-- Home Assistant 2023.1+
+- Home Assistant 2025.11.0+
 - HACS (for easy installation)
 
 ## Installation
@@ -69,14 +69,23 @@ This script will:
 
 ### Step 2: Install Integration via HACS
 
+**Note**: WrtManager is currently available as a custom repository in HACS while we prepare for official submission.
+
+#### Option A: HACS Custom Repository (Current)
 1. Open HACS in Home Assistant
 2. Go to "Integrations"
-3. Click the three dots in the top right
-4. Select "Custom repositories"
+3. Click the **three dots (⋮)** in the top right corner
+4. Select **"Custom repositories"**
 5. Add repository URL: `https://github.com/ohadlevy/wrtmanager-ha-integration`
-6. Category: "Integration"
-7. Click "Add"
-8. Search for "WrtManager" and install
+6. Set Category: **"Integration"**
+7. Click **"Add"**
+8. **Restart Home Assistant** (required for custom repository detection)
+9. Return to HACS → Integrations
+10. Search for **"WrtManager"** and click **"Download"**
+11. **Restart Home Assistant** again after installation
+
+#### Option B: Official HACS Repository (Coming Soon)
+Once submitted to the official HACS repository, you'll be able to find WrtManager directly in the HACS integration list without adding a custom repository.
 
 ### Step 3: Configure Integration
 

--- a/custom_components/wrtmanager/manifest.json
+++ b/custom_components/wrtmanager/manifest.json
@@ -13,5 +13,5 @@
   "homekit": {},
   "version": "0.8.0",
   "iot_class": "local_polling",
-  "homeassistant": "2025.1.0"
+  "homeassistant": "2025.11.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "WrtManager",
+  "content_in_root": false,
+  "filename": "wrtmanager",
+  "country": ["ALL"],
+  "homeassistant": "2025.11.0"
+}


### PR DESCRIPTION
## Summary
Prepares the integration for v0.8.0 release with full HACS compatibility support.

### Changes Made
- ✅ **HACS Configuration**: Added `hacs.json` with proper integration metadata  
- ✅ **Version Updates**: Updated Home Assistant requirement to 2025.11.0 (tested version)
- ✅ **Documentation**: Enhanced README.md with detailed HACS custom repository instructions
- ✅ **Installation Guide**: Clear step-by-step instructions for custom repository setup

### HACS Readiness Checklist
- ✅ Valid `hacs.json` configuration file
- ✅ Proper semantic versioning (v0.8.0)
- ✅ Updated `manifest.json` with accurate HA requirements  
- ✅ Comprehensive README.md with installation instructions
- ✅ Custom repository setup documented for limited availability

### Next Steps
After this PR is merged:
1. Create git tag `v0.8.0` for the release
2. Users can add as custom repository: `https://github.com/ohadlevy/wrtmanager-ha-integration`
3. Later: Submit to official HACS repository when ready

### Testing
- Pre-commit hooks: ✅ Passed
- Integration tested on Home Assistant 2025.11.x
- HACS configuration validated

## Test plan
- [x] Verify `hacs.json` syntax and content
- [x] Confirm manifest.json version consistency 
- [x] Test README.md custom repository instructions
- [x] Validate pre-commit hooks pass