### PR TITLE
Replace async_timeout with asyncio.timeout

### DIFF
--- a/custom_components/wrtmanager/ubus_client.py
+++ b/custom_components/wrtmanager/ubus_client.py
@@ -9,7 +9,6 @@ import secrets
 from typing import Any, Dict, List, Optional
 
 import aiohttp
-import async_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -281,7 +280,7 @@ class UbusClient:
             self._session = aiohttp.ClientSession(connector=connector)
 
         try:
-            async with async_timeout.timeout(self.timeout):
+            async with asyncio.timeout(self.timeout):
                 async with self._session.post(
                     self.base_url,
                     json=data,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.11"
 dependencies = [
     "homeassistant>=2023.1.0",
     "aiohttp>=3.8.0",
-    "async_timeout>=4.0.0",
     "aiofiles>=23.0.0",
 ]
 


### PR DESCRIPTION
## Summary
- Modernized timeout handling by replacing external `async_timeout` package with Python 3.11+ built-in `asyncio.timeout`
- Removed unnecessary dependency from `pyproject.toml`
- Kept `manifest.json` requirements empty per Home Assistant best practices

## Why This Change?
Issue #13 originally suggested adding `aiohttp` and `async_timeout` to `manifest.json`, but after investigation:

1. **aiohttp** - Already in Home Assistant core requirements, should NOT be duplicated in manifest.json
2. **async_timeout** - Not in HA core, BUT not needed since Python 3.11+ has `asyncio.timeout` built-in

Following HA developer docs: "only include requirements that are not required by the Core requirements.txt"

## Changes
- `ubus_client.py`: Replaced `async_timeout.timeout()` with `asyncio.timeout()`
- `pyproject.toml`: Removed `async_timeout>=4.0.0` from dependencies
- `manifest.json`: No changes (remains empty, as it should be)

## Test Results
✅ All 72 tests pass successfully

Fixes #13