### PR TITLE
Feature: Add WiFi client disconnect button (per-AP)

### DIFF
--- a/custom_components/wrtmanager/__init__.py
+++ b/custom_components/wrtmanager/__init__.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.SENSOR,
 ]
 

--- a/custom_components/wrtmanager/button.py
+++ b/custom_components/wrtmanager/button.py
@@ -1,0 +1,184 @@
+"""Button platform for WrtManager - WiFi client disconnect."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    ATTR_CONNECTED,
+    ATTR_HOSTNAME,
+    ATTR_INTERFACE,
+    ATTR_MAC,
+    ATTR_ROUTER,
+    DOMAIN,
+)
+from .coordinator import WrtManagerCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up WrtManager disconnect buttons."""
+    coordinator: WrtManagerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    if not coordinator.data:
+        _LOGGER.debug("Button setup skipped - no coordinator data available")
+        return
+
+    # Track created buttons to avoid duplicates
+    created_buttons: set[str] = set()
+
+    @callback
+    def _async_add_new_buttons() -> None:
+        """Add disconnect buttons for newly discovered devices."""
+        if not coordinator.data or "devices" not in coordinator.data:
+            return
+
+        new_entities = []
+        for device in coordinator.data["devices"]:
+            mac = device.get(ATTR_MAC)
+            router = device.get(ATTR_ROUTER)
+            interface = device.get(ATTR_INTERFACE)
+
+            if not mac or not router or not interface:
+                continue
+
+            # Unique key per device per router
+            button_key = f"{mac}_{router}"
+            if button_key in created_buttons:
+                continue
+
+            created_buttons.add(button_key)
+            new_entities.append(
+                WrtDisconnectButton(coordinator, mac, router, interface, config_entry)
+            )
+
+        if new_entities:
+            async_add_entities(new_entities)
+            _LOGGER.debug("Added %d new disconnect buttons", len(new_entities))
+
+    # Create buttons for initially known devices
+    _async_add_new_buttons()
+
+    # Listen for coordinator updates to add buttons for newly discovered devices
+    config_entry.async_on_unload(coordinator.async_add_listener(_async_add_new_buttons))
+
+
+class WrtDisconnectButton(CoordinatorEntity, ButtonEntity):
+    """Button to disconnect a WiFi client from a specific AP."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:wifi-remove"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: WrtManagerCoordinator,
+        mac: str,
+        router_host: str,
+        interface: str,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the disconnect button."""
+        super().__init__(coordinator)
+        self._mac = mac.upper()
+        self._router_host = router_host
+        self._interface = interface
+        self._config_entry = config_entry
+
+        # Include router in unique ID since same device can appear on multiple APs
+        router_id = router_host.replace(".", "_")
+        mac_id = mac.lower().replace(":", "_")
+        self._attr_unique_id = f"{DOMAIN}_{router_id}_{mac_id}_disconnect"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the button."""
+        router_name = self._get_router_name()
+        return f"Disconnect from {router_name}"
+
+    @property
+    def available(self) -> bool:
+        """Return True if button is available (device connected on this AP)."""
+        if not self.coordinator.last_update_success:
+            return False
+        device_data = self._get_device_data()
+        return device_data is not None and device_data.get(ATTR_CONNECTED, False)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info to group button under the WiFi client device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._mac)},
+            connections={(CONNECTION_NETWORK_MAC, self._mac)},
+        )
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Return extra state attributes."""
+        device_data = self._get_device_data()
+        attrs = {
+            "mac_address": self._mac,
+            "router": self._router_host,
+            "interface": self._interface,
+        }
+        if device_data:
+            hostname = device_data.get(ATTR_HOSTNAME)
+            if hostname:
+                attrs["hostname"] = hostname
+        return attrs
+
+    async def async_press(self) -> None:
+        """Disconnect the client when button is pressed."""
+        device_data = self._get_device_data()
+        if not device_data:
+            raise HomeAssistantError(
+                f"Device {self._mac} is not currently connected to {self._router_host}"
+            )
+
+        # Use current interface from live data (may have changed due to band steering)
+        interface = device_data.get(ATTR_INTERFACE, self._interface)
+
+        try:
+            success = await self.coordinator.disconnect_client(
+                self._router_host, interface, self._mac
+            )
+            if not success:
+                raise HomeAssistantError(
+                    f"Failed to disconnect {self._mac} from {self._router_host}. "
+                    f"Check logs - you may need to re-run the setup script on the router "
+                    f"to grant hostapd del_client permission."
+                )
+        except ValueError as ex:
+            raise HomeAssistantError(str(ex)) from ex
+
+    def _get_device_data(self) -> Dict[str, Any] | None:
+        """Get current device data for this MAC on this router."""
+        if not self.coordinator.data or "devices" not in self.coordinator.data:
+            return None
+
+        for device in self.coordinator.data["devices"]:
+            if device.get(ATTR_MAC) == self._mac and device.get(ATTR_ROUTER) == self._router_host:
+                return device
+        return None
+
+    def _get_router_name(self) -> str:
+        """Get friendly router name from config."""
+        for router_config in self._config_entry.data.get("routers", []):
+            if router_config.get("host") == self._router_host:
+                return router_config.get("name", self._router_host)
+        return self._router_host

--- a/custom_components/wrtmanager/coordinator.py
+++ b/custom_components/wrtmanager/coordinator.py
@@ -675,6 +675,46 @@ class WrtManagerCoordinator(DataUpdateCoordinator):
                 return device
         return None
 
+    async def disconnect_client(self, router_host: str, interface: str, mac_address: str) -> bool:
+        """Disconnect a WiFi client from a specific router/interface.
+
+        Args:
+            router_host: The router host to disconnect from.
+            interface: Wireless interface name (e.g. "phy0-ap0").
+            mac_address: MAC address of the client.
+
+        Returns:
+            True if successful, False otherwise.
+
+        Raises:
+            ValueError: If the router is not configured or not authenticated.
+        """
+        client = self.routers.get(router_host)
+        if not client:
+            raise ValueError(f"Router {router_host} is not configured")
+
+        session_id = self.sessions.get(router_host)
+        if not session_id:
+            raise ValueError(f"Router {router_host} is not authenticated")
+
+        _LOGGER.info(
+            "Disconnecting client %s from %s (interface: %s)",
+            mac_address,
+            router_host,
+            interface,
+        )
+
+        success = await client.disconnect_client(session_id, interface, mac_address)
+
+        if success:
+            _LOGGER.info("Successfully disconnected %s from %s", mac_address, router_host)
+            # Trigger a data refresh to update entity states
+            await self.async_request_refresh()
+        else:
+            _LOGGER.warning("Failed to disconnect %s from %s", mac_address, router_host)
+
+        return success
+
     def get_devices_by_router(self, router: str) -> List[Dict[str, Any]]:
         """Get all devices connected to a specific router."""
         if not self.data or "devices" not in self.data:

--- a/custom_components/wrtmanager/ubus_client.py
+++ b/custom_components/wrtmanager/ubus_client.py
@@ -166,9 +166,17 @@ class UbusClient:
                     )
                     return None
             elif result and len(result) == 1:
-                # Single element result is usually an error code
+                # Single element result: status code only, no data payload
                 error_code = result[0]
-                if error_code == 6:
+                if error_code == 0:
+                    # Success with no data (e.g. hostapd del_client)
+                    _LOGGER.debug(
+                        "ubus call %s.%s succeeded (no data returned)",
+                        service,
+                        method,
+                    )
+                    return {}
+                elif error_code == 6:
                     # Permission denied - common for dump APs
                     _LOGGER.debug(
                         "ubus call %s.%s: permission denied (code 6) - normal for dump APs",
@@ -187,12 +195,26 @@ class UbusClient:
                     )
                     return None
             else:
-                # Check for common errors that aren't really errors
-                if "error" in response_data and response_data["error"].get("code") == -32000:
+                # Handle JSON-RPC error responses
+                error = response_data.get("error", {})
+                error_code = error.get("code")
+                error_message = error.get("message", "Unknown")
+
+                if error_code == -32000:
                     # "Object not found" - normal for dump APs and missing services
                     _LOGGER.debug(
                         "ubus object/method not available: %s",
-                        response_data["error"].get("message", "Unknown"),
+                        error_message,
+                    )
+                    return None
+                elif error_code == -32002:
+                    # "Access denied" - ACL not configured for this method
+                    _LOGGER.warning(
+                        "ubus call %s.%s access denied - re-run setup script "
+                        "to update ACL permissions on %s",
+                        service,
+                        method,
+                        self.host,
                     )
                     return None
                 else:
@@ -330,6 +352,42 @@ class UbusClient:
         """Get system board information."""
         result = await self.call_ubus(session_id, "system", "board", {})
         return result if result else None
+
+    async def disconnect_client(
+        self,
+        session_id: str,
+        interface: str,
+        mac_address: str,
+        ban_time: int = 60000,
+    ) -> bool:
+        """Disconnect a WiFi client from a specific interface.
+
+        Uses hostapd del_client to deauthenticate the client.
+        A temporary ban_time prevents immediate reconnection.
+
+        Args:
+            session_id: Authenticated session ID.
+            interface: Wireless interface name (e.g. "phy0-ap0").
+            mac_address: MAC address of the client to disconnect.
+            ban_time: Temporary ban in ms (default 60s) to prevent immediate reconnect.
+
+        Returns:
+            True if the disconnect was successful, False otherwise.
+        """
+        hostapd_interface = f"hostapd.{interface}"
+        result = await self.call_ubus(
+            session_id,
+            hostapd_interface,
+            "del_client",
+            {
+                "addr": mac_address,
+                "deauth": True,
+                "reason": 5,
+                "ban_time": ban_time,
+            },
+        )
+        # del_client returns empty dict {} on success, None on failure
+        return result is not None
 
     async def close(self) -> None:
         """Close the HTTP session."""

--- a/scripts/setup_openwrt_ha_integration.sh
+++ b/scripts/setup_openwrt_ha_integration.sh
@@ -213,7 +213,8 @@ run_on_router "
         },
         \"write\": {
             \"ubus\": {
-                \"session\": [ \"login\", \"access\" ]
+                \"session\": [ \"login\", \"access\" ],
+                \"hostapd.*\": [ \"del_client\" ]
             }
         }
     }

--- a/tests/test_disconnect_client.py
+++ b/tests/test_disconnect_client.py
@@ -1,0 +1,456 @@
+"""Tests for WiFi client disconnect feature."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "custom_components" / "wrtmanager"))
+
+from ubus_client import UbusClient
+
+# ─── UbusClient.disconnect_client tests ───
+
+
+@pytest.mark.asyncio
+async def test_disconnect_client_success():
+    """Test successful client disconnect via hostapd del_client."""
+    response = {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "result": [0, {}],
+    }
+
+    async def mock_make_request(self, request_data):
+        return response
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            result = await client.disconnect_client("test_session", "phy0-ap0", "AA:BB:CC:DD:EE:FF")
+            assert result is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_client_success_no_data():
+    """Test successful disconnect when router returns [0] (no data payload)."""
+    response = {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "result": [0],  # Success with no data — real router behavior
+    }
+
+    async def mock_make_request(self, request_data):
+        return response
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            result = await client.disconnect_client("test_session", "phy0-ap0", "AA:BB:CC:DD:EE:FF")
+            assert result is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_client_failure():
+    """Test failed client disconnect (permission denied)."""
+    response = {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "result": [6],
+    }
+
+    async def mock_make_request(self, request_data):
+        return response
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            result = await client.disconnect_client("test_session", "phy0-ap0", "AA:BB:CC:DD:EE:FF")
+            assert result is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_client_uses_hostapd_interface():
+    """Test that disconnect prepends hostapd. to the interface name."""
+    captured_requests = []
+
+    async def mock_make_request(self, request_data):
+        captured_requests.append(request_data)
+        return {"jsonrpc": "2.0", "id": 100, "result": [0, {}]}
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            await client.disconnect_client("test_session", "phy0-ap0", "AA:BB:CC:DD:EE:FF")
+
+    assert len(captured_requests) == 1
+    params = captured_requests[0]["params"]
+    assert params[1] == "hostapd.phy0-ap0"
+    assert params[2] == "del_client"
+    assert params[3]["addr"] == "AA:BB:CC:DD:EE:FF"
+    assert params[3]["deauth"] is True
+    assert params[3]["reason"] == 5
+    assert params[3]["ban_time"] == 60000
+
+
+@pytest.mark.asyncio
+async def test_disconnect_client_custom_ban_time():
+    """Test disconnect with custom ban_time."""
+    captured_requests = []
+
+    async def mock_make_request(self, request_data):
+        captured_requests.append(request_data)
+        return {"jsonrpc": "2.0", "id": 100, "result": [0, {}]}
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            await client.disconnect_client(
+                "test_session", "phy0-ap0", "AA:BB:CC:DD:EE:FF", ban_time=120000
+            )
+
+    assert captured_requests[0]["params"][3]["ban_time"] == 120000
+
+
+@pytest.mark.asyncio
+async def test_disconnect_client_object_not_found():
+    """Test disconnect when hostapd interface doesn't exist."""
+    response = {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "error": {"code": -32000, "message": "Object not found"},
+    }
+
+    async def mock_make_request(self, request_data):
+        return response
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            result = await client.disconnect_client(
+                "test_session", "nonexistent", "AA:BB:CC:DD:EE:FF"
+            )
+            assert result is False
+
+
+@pytest.mark.asyncio
+async def test_call_ubus_single_element_success():
+    """Test that call_ubus treats [0] as success, not an error."""
+    response = {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "result": [0],
+    }
+
+    async def mock_make_request(self, request_data):
+        return response
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            result = await client.call_ubus("test_session", "hostapd.phy0-ap0", "del_client", {})
+            assert result == {}  # Should return empty dict, not None
+
+
+@pytest.mark.asyncio
+async def test_call_ubus_access_denied():
+    """Test that call_ubus handles -32002 Access denied response."""
+    response = {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "error": {"code": -32002, "message": "Access denied"},
+    }
+
+    async def mock_make_request(self, request_data):
+        return response
+
+    with patch.object(UbusClient, "_make_request", mock_make_request):
+        async with UbusClient("192.168.1.1", "hass", "password") as client:
+            result = await client.call_ubus("test_session", "hostapd.phy0-ap0", "del_client", {})
+            assert result is None
+
+
+# ─── Coordinator disconnect_client tests ───
+
+
+@pytest.mark.asyncio
+async def test_coordinator_disconnect_success():
+    """Test coordinator disconnect_client delegates to the right UbusClient."""
+    from custom_components.wrtmanager.coordinator import WrtManagerCoordinator
+
+    mock_client = AsyncMock()
+    mock_client.disconnect_client = AsyncMock(return_value=True)
+    mock_client.close = AsyncMock()
+
+    coordinator = Mock(spec=WrtManagerCoordinator)
+    coordinator.routers = {"192.168.1.1": mock_client}
+    coordinator.sessions = {"192.168.1.1": "test_session"}
+    coordinator.async_request_refresh = AsyncMock()
+
+    result = await WrtManagerCoordinator.disconnect_client(
+        coordinator, "192.168.1.1", "phy0-ap0", "AA:BB:CC:DD:EE:FF"
+    )
+
+    assert result is True
+    mock_client.disconnect_client.assert_called_once_with(
+        "test_session", "phy0-ap0", "AA:BB:CC:DD:EE:FF"
+    )
+    coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_disconnect_unknown_router():
+    """Test coordinator raises ValueError for unknown router."""
+    from custom_components.wrtmanager.coordinator import WrtManagerCoordinator
+
+    coordinator = Mock(spec=WrtManagerCoordinator)
+    coordinator.routers = {}
+    coordinator.sessions = {}
+
+    with pytest.raises(ValueError, match="not configured"):
+        await WrtManagerCoordinator.disconnect_client(
+            coordinator, "unknown.host", "phy0-ap0", "AA:BB:CC:DD:EE:FF"
+        )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_disconnect_not_authenticated():
+    """Test coordinator raises ValueError when router not authenticated."""
+    from custom_components.wrtmanager.coordinator import WrtManagerCoordinator
+
+    mock_client = AsyncMock()
+    coordinator = Mock(spec=WrtManagerCoordinator)
+    coordinator.routers = {"192.168.1.1": mock_client}
+    coordinator.sessions = {}
+
+    with pytest.raises(ValueError, match="not authenticated"):
+        await WrtManagerCoordinator.disconnect_client(
+            coordinator, "192.168.1.1", "phy0-ap0", "AA:BB:CC:DD:EE:FF"
+        )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_disconnect_failure_no_refresh():
+    """Test coordinator does not refresh when disconnect fails."""
+    from custom_components.wrtmanager.coordinator import WrtManagerCoordinator
+
+    mock_client = AsyncMock()
+    mock_client.disconnect_client = AsyncMock(return_value=False)
+
+    coordinator = Mock(spec=WrtManagerCoordinator)
+    coordinator.routers = {"192.168.1.1": mock_client}
+    coordinator.sessions = {"192.168.1.1": "test_session"}
+    coordinator.async_request_refresh = AsyncMock()
+
+    result = await WrtManagerCoordinator.disconnect_client(
+        coordinator, "192.168.1.1", "phy0-ap0", "AA:BB:CC:DD:EE:FF"
+    )
+
+    assert result is False
+    coordinator.async_request_refresh.assert_not_called()
+
+
+# ─── Button entity logic tests ───
+
+
+def test_button_unique_id_format():
+    """Test button unique ID includes router and MAC."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Main Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button._attr_unique_id == "wrtmanager_192_168_1_1_aa_bb_cc_dd_ee_ff_disconnect"
+
+
+def test_button_name_uses_router_name():
+    """Test button name uses friendly router name from config."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Living Room AP"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button.name == "Disconnect from Living Room AP"
+
+
+def test_button_available_when_connected():
+    """Test button is available when device is connected on this AP."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.last_update_success = True
+    coordinator.data = {
+        "devices": [
+            {
+                "mac_address": "AA:BB:CC:DD:EE:FF",
+                "router": "192.168.1.1",
+                "interface": "phy0-ap0",
+                "connected": True,
+            }
+        ]
+    }
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button.available is True
+
+
+def test_button_unavailable_when_disconnected():
+    """Test button is unavailable when device is not on this AP."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.last_update_success = True
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button.available is False
+
+
+def test_button_unavailable_when_coordinator_failed():
+    """Test button is unavailable when coordinator update failed."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.last_update_success = False
+    coordinator.data = {
+        "devices": [
+            {
+                "mac_address": "AA:BB:CC:DD:EE:FF",
+                "router": "192.168.1.1",
+                "interface": "phy0-ap0",
+                "connected": True,
+            }
+        ]
+    }
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button.available is False
+
+
+def test_button_device_info_groups_with_presence_sensor():
+    """Test button device_info uses same identifiers as presence sensor."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    device_info = button.device_info
+    assert ("wrtmanager", "AA:BB:CC:DD:EE:FF") in device_info["identifiers"]
+
+
+def test_button_extra_attributes():
+    """Test button exposes useful extra state attributes."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {
+        "devices": [
+            {
+                "mac_address": "AA:BB:CC:DD:EE:FF",
+                "router": "192.168.1.1",
+                "interface": "phy0-ap0",
+                "connected": True,
+                "hostname": "my-phone",
+            }
+        ]
+    }
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    attrs = button.extra_state_attributes
+    assert attrs["mac_address"] == "AA:BB:CC:DD:EE:FF"
+    assert attrs["router"] == "192.168.1.1"
+    assert attrs["interface"] == "phy0-ap0"
+    assert attrs["hostname"] == "my-phone"
+
+
+def test_button_router_name_fallback():
+    """Test button falls back to host when router name not in config."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "10.0.0.1", "name": "Other Router"}]}
+
+    button = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button.name == "Disconnect from 192.168.1.1"
+
+
+def test_button_multiple_devices_per_router():
+    """Test that buttons for different devices on same router have unique IDs."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {"routers": [{"host": "192.168.1.1", "name": "Router"}]}
+
+    button1 = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:01", "192.168.1.1", "phy0-ap0", config_entry
+    )
+    button2 = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:02", "192.168.1.1", "phy0-ap0", config_entry
+    )
+
+    assert button1._attr_unique_id != button2._attr_unique_id
+
+
+def test_button_same_device_different_routers():
+    """Test that buttons for same device on different routers have unique IDs."""
+    from custom_components.wrtmanager.button import WrtDisconnectButton
+
+    coordinator = Mock()
+    coordinator.data = {"devices": []}
+    config_entry = Mock()
+    config_entry.data = {
+        "routers": [
+            {"host": "192.168.1.1", "name": "Router 1"},
+            {"host": "192.168.1.2", "name": "Router 2"},
+        ]
+    }
+
+    button1 = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.1", "phy0-ap0", config_entry
+    )
+    button2 = WrtDisconnectButton(
+        coordinator, "AA:BB:CC:DD:EE:FF", "192.168.1.2", "phy0-ap0", config_entry
+    )
+
+    assert button1._attr_unique_id != button2._attr_unique_id
+    # Both should group under the same device
+    assert button1.device_info["identifiers"] == button2.device_info["identifiers"]


### PR DESCRIPTION
## Summary

- Adds per-AP disconnect buttons for WiFi clients using OpenWrt's `hostapd.<iface>.del_client` method
- Each connected device gets a "Disconnect from <router name>" button per AP it's connected to
- Button is only available when the device is actually connected on that AP
- Includes a 60-second temporary ban to prevent immediate reconnection
- Updates the router setup script ACL to grant `hostapd.*.del_client` write permission

## Changes

| File | Change |
|------|--------|
| `ubus_client.py` | Add `disconnect_client()` method |
| `coordinator.py` | Add `disconnect_client()` with router/session lookup |
| `button.py` | New platform - `WrtDisconnectButton` entity per device per AP |
| `__init__.py` | Register `Platform.BUTTON` |
| `setup_openwrt_ha_integration.sh` | Add `hostapd.*: del_client` to write ACL |
| `tests/test_disconnect_client.py` | 19 tests covering all layers |

## How it works

1. Each WiFi client device gets a disconnect button per AP it's seen on
2. Pressing the button calls `hostapd.<interface>.del_client` on the specific router
3. A 60s temporary ban prevents the device from immediately reconnecting
4. After disconnect, the coordinator refreshes to update entity states
5. Button becomes unavailable when the device is no longer on that AP

## Test plan

- [x] 19 new tests passing (ubus client, coordinator, button entity)
- [x] All 224 existing tests still pass
- [x] Pre-commit hooks (black, isort, flake8, pylint) all pass
- [x] Manual test: disconnect a device from a specific AP on a real router
- [x] Verify setup script grants correct ACL permissions on a fresh router

## Note

Users need to re-run the setup script on their routers to get the new `hostapd.*.del_client` write permission in the ACL.