### PR TITLE
Fix: Use actual OpenWrt network names instead of VLAN heuristics

### DIFF
--- a/custom_components/wrtmanager/binary_sensor.py
+++ b/custom_components/wrtmanager/binary_sensor.py
@@ -23,15 +23,13 @@ from .const import (
     ATTR_HOSTNAME,
     ATTR_IP,
     ATTR_MAC,
+    ATTR_NETWORK_NAME,
     ATTR_PRIMARY_AP,
     ATTR_ROAMING_COUNT,
     ATTR_ROUTER,
     ATTR_SIGNAL_DBM,
     ATTR_VENDOR,
-    ATTR_VLAN_ID,
-    CONF_VLAN_NAMES,
     DOMAIN,
-    VLAN_NAMES,
     classify_signal_quality,
 )
 from .coordinator import WrtManagerCoordinator
@@ -697,15 +695,10 @@ class WrtDevicePresenceSensor(CoordinatorEntity, BinarySensorEntity):
         if primary_ap:
             attributes["primary_ap"] = primary_ap
 
-        # Add VLAN information
-        vlan_id = device_data.get(ATTR_VLAN_ID)
-        if vlan_id:
-            attributes["vlan_id"] = vlan_id
-            # Get custom VLAN names from config entry options
-            custom_vlan_names = self._config_entry.options.get(CONF_VLAN_NAMES, {})
-            # Merge custom names with defaults
-            vlan_names = {**VLAN_NAMES, **custom_vlan_names}
-            attributes["vlan_name"] = vlan_names.get(vlan_id, f"VLAN {vlan_id}")
+        # Add network information from OpenWrt
+        network_name = device_data.get(ATTR_NETWORK_NAME)
+        if network_name:
+            attributes["network"] = network_name
 
         # Add signal quality description
         signal = device_data.get(ATTR_SIGNAL_DBM)

--- a/custom_components/wrtmanager/config_flow.py
+++ b/custom_components/wrtmanager/config_flow.py
@@ -26,7 +26,6 @@ from .const import (
     CONF_ROUTER_VERIFY_SSL,
     CONF_ROUTERS,
     CONF_SCAN_INTERVAL,
-    CONF_VLAN_NAMES,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_USE_HTTPS,
     DEFAULT_USERNAME,
@@ -36,7 +35,6 @@ from .const import (
     ERROR_CANNOT_CONNECT,
     ERROR_INVALID_AUTH,
     ERROR_UNKNOWN,
-    VLAN_NAMES,
 )
 from .ubus_client import UbusClient
 
@@ -397,8 +395,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             action = user_input.get("action")
             if action == "scan_interval":
                 return await self.async_step_scan_interval()
-            elif action == "vlan_names":
-                return await self.async_step_vlan_names()
             elif action == "router_credentials":
                 return await self.async_step_select_router()
             elif action == "add_router":
@@ -414,7 +410,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required("action"): vol.In(
                         {
                             "scan_interval": "Configure Polling Interval",
-                            "vlan_names": "Customize VLAN Names",
                             "router_credentials": "Update Router Credentials",
                             "add_router": "Add New Router",
                             "remove_router": "Remove Router",
@@ -457,47 +452,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     "Higher values reduce network traffic but may result in stale data. "
                     "Range: 10-300 seconds."
                 )
-            },
-        )
-
-    async def async_step_vlan_names(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Configure VLAN names."""
-        if user_input is not None:
-            # Transform input into proper VLAN names dictionary
-            vlan_names = {}
-            for key, value in user_input.items():
-                if key.startswith("vlan_") and value.strip():
-                    vlan_id = int(key.replace("vlan_", ""))
-                    vlan_names[vlan_id] = value.strip()
-
-            # Preserve existing options and update VLAN names
-            new_options = dict(self.config_entry.options)
-            new_options[CONF_VLAN_NAMES] = vlan_names
-
-            return self.async_create_entry(title="", data=new_options)
-
-        # Get current VLAN names from options or use defaults
-        current_vlan_names = self.config_entry.options.get(CONF_VLAN_NAMES, {})
-
-        # Create form schema for VLAN customization
-        options_schema = vol.Schema(
-            {
-                vol.Optional(
-                    f"vlan_{vlan_id}",
-                    default=current_vlan_names.get(
-                        vlan_id, VLAN_NAMES.get(vlan_id, f"VLAN {vlan_id}")
-                    ),
-                ): str
-                for vlan_id in [1, 2, 3, 10, 13, 20, 100]
-            }
-        )
-
-        return self.async_show_form(
-            step_id="vlan_names",
-            data_schema=options_schema,
-            description_placeholders={
-                "description": "Customize VLAN names that will be displayed in Home Assistant. "
-                "These names will be used in device attributes and sensor breakdowns."
             },
         )
 

--- a/custom_components/wrtmanager/const.py
+++ b/custom_components/wrtmanager/const.py
@@ -12,7 +12,6 @@ CONF_ROUTER_PASSWORD = "password"  # nosec B105
 CONF_ROUTER_DESCRIPTION = "description"
 CONF_ROUTER_USE_HTTPS = "use_https"
 CONF_ROUTER_VERIFY_SSL = "verify_ssl"
-CONF_VLAN_NAMES = "vlan_names"
 CONF_SCAN_INTERVAL = "scan_interval"
 
 # Default values
@@ -36,7 +35,7 @@ ATTR_DEVICE_TYPE = "device_type"
 ATTR_SIGNAL_DBM = "signal_dbm"
 ATTR_ROUTER = "router"
 ATTR_INTERFACE = "interface"
-ATTR_VLAN_ID = "vlan_id"
+ATTR_NETWORK_NAME = "network_name"
 ATTR_SSID = "ssid"
 ATTR_CONNECTED = "connected"
 ATTR_LAST_SEEN = "last_seen"
@@ -58,21 +57,6 @@ ATTR_NETWORK_INTERFACE = "network_interface"
 # Entity types
 ENTITY_TYPE_DEVICE_PRESENCE = "device_presence"
 ENTITY_TYPE_SIGNAL_STRENGTH = "signal_strength"
-
-# VLAN mapping
-VLAN_MAIN = 1
-VLAN_IOT = 3
-VLAN_GUEST = 13
-
-VLAN_NAMES = {
-    1: "Main Network",
-    2: "Management Network",
-    3: "IoT Network",
-    10: "Secondary Network",
-    20: "Work Network",
-    100: "Guest Network",
-    # Add your custom VLANs here
-}
 
 # Device types
 DEVICE_TYPE_IOT_SWITCH = "IoT Switch"

--- a/custom_components/wrtmanager/coordinator.py
+++ b/custom_components/wrtmanager/coordinator.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Pattern, Set
+from typing import Any, Dict, List, Optional, Set
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
@@ -22,12 +21,12 @@ from .const import (
     ATTR_IP,
     ATTR_LAST_SEEN,
     ATTR_MAC,
+    ATTR_NETWORK_NAME,
     ATTR_PRIMARY_AP,
     ATTR_ROAMING_COUNT,
     ATTR_ROUTER,
     ATTR_SIGNAL_DBM,
     ATTR_VENDOR,
-    ATTR_VLAN_ID,
     CONF_ROUTER_USE_HTTPS,
     CONF_ROUTER_VERIFY_SSL,
     CONF_ROUTERS,
@@ -82,9 +81,6 @@ class WrtManagerCoordinator(DataUpdateCoordinator):
         # DHCP router tracking for optimization
         self._dhcp_routers: Set[str] = set()  # Track which routers actually serve DHCP
         self._tried_dhcp: Set[str] = set()  # Track which routers we've already tested
-
-        # Compile regex patterns once for performance optimization
-        self._vlan_pattern: Pattern[str] = re.compile(r"vlan(\d+)")
 
     async def _async_update_data(self) -> Dict[str, Any]:
         """Fetch data from all routers."""
@@ -180,8 +176,13 @@ class WrtManagerCoordinator(DataUpdateCoordinator):
                     _LOGGER.warning("Fallback DHCP query failed for %s: %s", fallback_host, ex)
                     self._tried_dhcp.add(fallback_host)
 
+        # Build interface-to-network mapping from wireless status data
+        interface_network_map = self._build_interface_network_map(interfaces)
+
         # Correlate and enrich device data
-        enriched_devices = self._correlate_device_data(all_devices, dhcp_data)
+        enriched_devices = self._correlate_device_data(
+            all_devices, dhcp_data, interface_network_map
+        )
 
         # Update roaming detection
         self._update_roaming_detection(enriched_devices)
@@ -403,7 +404,10 @@ class WrtManagerCoordinator(DataUpdateCoordinator):
         return dhcp_devices
 
     def _correlate_device_data(
-        self, wifi_devices: List[Dict[str, Any]], dhcp_data: Dict[str, Any]
+        self,
+        wifi_devices: List[Dict[str, Any]],
+        dhcp_data: Dict[str, Any],
+        interface_network_map: Optional[Dict[str, str]] = None,
     ) -> List[Dict[str, Any]]:
         """Correlate WiFi devices with DHCP data and enrich with additional info."""
         enriched_devices = []
@@ -423,64 +427,59 @@ class WrtManagerCoordinator(DataUpdateCoordinator):
                 device[ATTR_VENDOR] = device_info.get("vendor")
                 device[ATTR_DEVICE_TYPE] = device_info.get("device_type")
 
-            # Determine VLAN based on IP address or interface
-            device[ATTR_VLAN_ID] = self._determine_vlan(device)
+            # Look up OpenWrt network name from wireless status data
+            if interface_network_map:
+                router = device.get(ATTR_ROUTER, "")
+                interface = device.get(ATTR_INTERFACE, "")
+                map_key = f"{router}:{interface}"
+                device[ATTR_NETWORK_NAME] = interface_network_map.get(map_key)
 
             enriched_devices.append(device)
 
         return enriched_devices
 
-    def _determine_vlan(self, device: Dict[str, Any]) -> int:
-        """Determine VLAN ID from device information."""
-        interface = device.get(ATTR_INTERFACE, "")
+    @staticmethod
+    def _build_interface_network_map(
+        interfaces: Dict[str, Any],
+    ) -> Dict[str, str]:
+        """Build a mapping from (router:interface) to OpenWrt network name.
 
-        # Try to determine VLAN from WiFi interface name patterns
-        if interface:
-            # Common OpenWrt VLAN interface naming patterns
-            interface_lower = interface.lower()
+        Extracts network assignments from wireless status data which contains
+        the actual OpenWrt network configuration for each wireless interface.
 
-            # Check for explicit VLAN tags in interface names
-            if "vlan" in interface_lower:
-                # Extract VLAN ID from names like "wlan0-vlan3", "phy0-ap1-vlan13"
-                vlan_match = re.search(r"vlan(\d+)", interface_lower)
-                if vlan_match:
-                    return int(vlan_match.group(1))
+        Returns:
+            Dict mapping "router_host:interface_name" to network name string.
+        """
+        network_map: Dict[str, str] = {}
 
-            # Check for common naming patterns (generic, not network-specific)
-            if any(keyword in interface_lower for keyword in ["iot", "smart", "things"]):
-                return 3  # Common IoT VLAN
-            elif any(keyword in interface_lower for keyword in ["guest", "visitor", "public"]):
-                return 100  # Common Guest VLAN
-            elif any(keyword in interface_lower for keyword in ["main", "default", "lan"]):
-                return 1  # Main VLAN
+        for router_host, router_interfaces in interfaces.items():
+            for interface_name, interface_data in router_interfaces.items():
+                # Only process wireless radio data (has 'interfaces' key)
+                if not isinstance(interface_data, dict) or "interfaces" not in interface_data:
+                    continue
 
-            # Check for multi-AP interface patterns (ap0=main, ap1=secondary, ap2=guest)
-            elif "ap1" in interface_lower:
-                return 10  # Secondary network
-            elif "ap2" in interface_lower:
-                return 100  # Guest network
-            elif "ap0" in interface_lower:
-                return 1  # Main network
+                radio_interfaces = interface_data.get("interfaces", [])
+                if not isinstance(radio_interfaces, list):
+                    continue
 
-        # For devices with IP addresses, try to infer from common subnet patterns
-        ip = device.get(ATTR_IP)
-        if ip:
-            # Common patterns - these are generic enough for most networks
-            ip_parts = ip.split(".")
-            if len(ip_parts) >= 3:
-                third_octet = ip_parts[2]
-                # Many networks use the third octet to indicate VLAN
-                try:
-                    vlan_candidate = int(third_octet)
-                    # Only return as VLAN if it's a reasonable VLAN ID (1-4094)
-                    if 1 <= vlan_candidate <= 4094:
-                        return vlan_candidate
-                except ValueError:
-                    # If the third octet is not an integer, we cannot infer a VLAN ID from it.
-                    # This is expected for some devices; default VLAN will be used below.
-                    pass
+                for iface in radio_interfaces:
+                    ifname = iface.get("ifname")
+                    config = iface.get("config", {})
+                    network = config.get("network")
 
-        return 1  # Default to main VLAN
+                    if ifname and network:
+                        # network can be a list (e.g. ['lan']) or string
+                        if isinstance(network, list):
+                            net_name = network[0] if network else None
+                        else:
+                            net_name = network
+
+                        if net_name:
+                            map_key = f"{router_host}:{ifname}"
+                            network_map[map_key] = net_name
+
+        _LOGGER.debug("Interface-to-network map: %s", network_map)
+        return network_map
 
     def _update_roaming_detection(self, devices: List[Dict[str, Any]]) -> None:
         """Update roaming detection for devices."""

--- a/custom_components/wrtmanager/sensor.py
+++ b/custom_components/wrtmanager/sensor.py
@@ -40,13 +40,11 @@ from .const import (
     ATTR_HOSTNAME,
     ATTR_INTERFACE,
     ATTR_MAC,
+    ATTR_NETWORK_NAME,
     ATTR_ROUTER,
     ATTR_SIGNAL_DBM,
-    ATTR_VLAN_ID,
     CONF_ROUTERS,
-    CONF_VLAN_NAMES,
     DOMAIN,
-    VLAN_NAMES,
     classify_signal_quality,
 )
 from .coordinator import WrtManagerCoordinator
@@ -429,46 +427,40 @@ class WrtManagerDeviceCountSensor(WrtManagerSensorBase):
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
-        """Return device breakdown by VLAN."""
+        """Return device breakdown by network and device type."""
         router_devices = self._get_router_devices()
         if not router_devices:
             return {}
 
-        # Get custom VLAN names from config entry options
-        custom_vlan_names = self._config_entry.options.get(CONF_VLAN_NAMES, {})
-        # Merge custom names with defaults
-        vlan_names = {**VLAN_NAMES, **custom_vlan_names}
-
-        # Count devices by VLAN and device type
-        vlan_counts = {}
+        # Count devices by network and device type
+        network_counts = {}
         device_type_counts = {}
 
         for device in router_devices:
-            # Count by VLAN
-            vlan_id = device.get(ATTR_VLAN_ID, 1)
-            vlan_name = vlan_names.get(vlan_id, f"VLAN {vlan_id}")
-            vlan_key = vlan_name.lower().replace(" ", "_").replace("-", "_")
-            vlan_counts[vlan_key] = vlan_counts.get(vlan_key, 0) + 1
+            # Count by OpenWrt network name
+            network_name = device.get(ATTR_NETWORK_NAME)
+            if network_name:
+                net_key = network_name.lower().replace(" ", "_").replace("-", "_")
+                network_counts[net_key] = network_counts.get(net_key, 0) + 1
 
             # Count by device type for categorization
             device_type = device.get(ATTR_DEVICE_TYPE, "Unknown Device")
             type_key = device_type.lower().replace(" ", "_").replace("-", "_")
             device_type_counts[type_key] = device_type_counts.get(type_key, 0) + 1
 
-        # Create dynamic attributes based on actual VLANs and device types found
         attributes = {}
 
-        # Add VLAN breakdown
-        for vlan_key, count in vlan_counts.items():
-            attributes[f"{vlan_key}_devices"] = count
+        # Add network breakdown
+        for net_key, count in network_counts.items():
+            attributes[f"{net_key}_devices"] = count
 
         # Add device type categorization breakdown
         for type_key, count in device_type_counts.items():
             attributes[f"{type_key}_count"] = count
 
-        # Add total if we have multiple VLANs
-        if len(vlan_counts) > 1:
-            attributes["total_devices"] = sum(vlan_counts.values())
+        # Add total if we have multiple networks
+        if len(network_counts) > 1:
+            attributes["total_devices"] = sum(network_counts.values())
 
         return attributes
 
@@ -527,14 +519,8 @@ class WrtManagerInterfaceDeviceCountSensor(WrtManagerSensorBase):
         if not interface_devices:
             return {}
 
-        # Get custom VLAN names from config entry options
-        custom_vlan_names = self._config_entry.options.get(CONF_VLAN_NAMES, {})
-        # Merge custom names with defaults
-        vlan_names = {**VLAN_NAMES, **custom_vlan_names}
-
         # Analyze devices connected to this interface
         signal_readings = []
-        vlan_counts = {}
         device_type_counts = {}
 
         for device in interface_devices:
@@ -543,15 +529,8 @@ class WrtManagerInterfaceDeviceCountSensor(WrtManagerSensorBase):
             if signal is not None:
                 signal_readings.append(signal)
 
-            # Count by VLAN
-            vlan_id = device.get(ATTR_VLAN_ID, 1)
-            vlan_name = vlan_names.get(vlan_id, f"VLAN {vlan_id}")
-            vlan_key = vlan_name.lower().replace(" ", "_").replace("-", "_")
-            vlan_counts[vlan_key] = vlan_counts.get(vlan_key, 0) + 1
-
             # Count by device type for categorization
             device_type = device.get(ATTR_DEVICE_TYPE, "Unknown Device")
-            # Create a clean key for device type counting
             type_key = device_type.lower().replace(" ", "_").replace("-", "_")
             device_type_counts[type_key] = device_type_counts.get(type_key, 0) + 1
 
@@ -560,12 +539,6 @@ class WrtManagerInterfaceDeviceCountSensor(WrtManagerSensorBase):
             "router": self._router_name,
             "total_devices": len(interface_devices),
         }
-
-        # Add VLAN breakdown if devices exist
-        if vlan_counts:
-            attributes.update(
-                {f"{vlan_key}_devices": count for vlan_key, count in vlan_counts.items()}
-            )
 
         # Add device type categorization breakdown
         if device_type_counts:

--- a/custom_components/wrtmanager/translations/en.json
+++ b/custom_components/wrtmanager/translations/en.json
@@ -66,19 +66,6 @@
           "action": "Configuration Option"
         }
       },
-      "vlan_names": {
-        "title": "Customize VLAN Names",
-        "description": "{description}",
-        "data": {
-          "vlan_1": "VLAN 1 Name",
-          "vlan_2": "VLAN 2 Name",
-          "vlan_3": "VLAN 3 Name",
-          "vlan_10": "VLAN 10 Name",
-          "vlan_13": "VLAN 13 Name",
-          "vlan_20": "VLAN 20 Name",
-          "vlan_100": "VLAN 100 Name"
-        }
-      },
       "select_router": {
         "title": "Select Router",
         "description": "{description}",

--- a/tests/test_config_flow_scan_interval.py
+++ b/tests/test_config_flow_scan_interval.py
@@ -154,7 +154,7 @@ async def test_scan_interval_preserves_existing_options():
                 }
             ]
         },
-        options={CONF_SCAN_INTERVAL: 60, "vlan_names": {1: "Main Network", 2: "Guest Network"}},
+        options={CONF_SCAN_INTERVAL: 60, "some_other_option": "test_value"},
         entry_id="test_entry",
     )
 
@@ -166,7 +166,7 @@ async def test_scan_interval_preserves_existing_options():
     assert result["type"] == "create_entry"
     assert result["data"][CONF_SCAN_INTERVAL] == 90
     # Verify other options are preserved
-    assert result["data"]["vlan_names"] == {1: "Main Network", 2: "Guest Network"}
+    assert result["data"]["some_other_option"] == "test_value"
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -269,50 +269,43 @@ def test_memory_usage_calculation():
     assert calculate_memory_usage(None) is None
 
 
-def test_device_vlan_counting():
-    """Test counting devices by VLAN."""
+def test_device_network_counting():
+    """Test counting devices by network name."""
 
-    def count_devices_by_vlan(devices, target_router):
-        """Count devices by VLAN for a specific router."""
-        vlan_counts = {"main": 0, "iot": 0, "guest": 0, "unknown": 0}
+    def count_devices_by_network(devices, target_router):
+        """Count devices by network for a specific router."""
+        network_counts = {}
 
         for device in devices:
             if device.get("router") == target_router:
-                vlan = device.get("vlan_id", 1)
-                if vlan == 1:
-                    vlan_counts["main"] += 1
-                elif vlan == 3:
-                    vlan_counts["iot"] += 1
-                elif vlan == 13:
-                    vlan_counts["guest"] += 1
-                else:
-                    vlan_counts["unknown"] += 1
+                network = device.get("network_name", "unknown")
+                network_counts[network] = network_counts.get(network, 0) + 1
 
-        return vlan_counts
+        return network_counts
 
     devices = [
-        {"mac_address": "AA:BB:CC:DD:EE:01", "router": "192.168.1.1", "vlan_id": 1},
-        {"mac_address": "AA:BB:CC:DD:EE:02", "router": "192.168.1.1", "vlan_id": 3},
-        {"mac_address": "AA:BB:CC:DD:EE:03", "router": "192.168.1.1", "vlan_id": 13},
-        {"mac_address": "AA:BB:CC:DD:EE:04", "router": "192.168.1.1", "vlan_id": 99},
+        {"mac_address": "AA:BB:CC:DD:EE:01", "router": "192.168.1.1", "network_name": "lan"},
+        {"mac_address": "AA:BB:CC:DD:EE:02", "router": "192.168.1.1", "network_name": "iot"},
+        {"mac_address": "AA:BB:CC:DD:EE:03", "router": "192.168.1.1", "network_name": "guest"},
+        {"mac_address": "AA:BB:CC:DD:EE:04", "router": "192.168.1.1", "network_name": "work"},
         {
             "mac_address": "AA:BB:CC:DD:EE:05",
             "router": "192.168.1.2",
-            "vlan_id": 1,
+            "network_name": "lan",
         },  # Different router
     ]
 
-    result = count_devices_by_vlan(devices, "192.168.1.1")
+    result = count_devices_by_network(devices, "192.168.1.1")
 
-    assert result["main"] == 1
+    assert result["lan"] == 1
     assert result["iot"] == 1
     assert result["guest"] == 1
-    assert result["unknown"] == 1
+    assert result["work"] == 1
 
     # Test with different router
-    result = count_devices_by_vlan(devices, "192.168.1.2")
-    assert result["main"] == 1
-    assert result["iot"] == 0
+    result = count_devices_by_network(devices, "192.168.1.2")
+    assert result["lan"] == 1
+    assert result.get("iot", 0) == 0
 
 
 def test_uptime_formatting():

--- a/tests/test_dhcp_polling_optimization.py
+++ b/tests/test_dhcp_polling_optimization.py
@@ -89,7 +89,7 @@ class MockCoordinator(WrtManagerCoordinator):
                         }
         return dhcp_devices
 
-    def _correlate_device_data(self, wifi_devices, dhcp_data):
+    def _correlate_device_data(self, wifi_devices, dhcp_data, interface_network_map=None):
         """Mock device correlation for tests."""
         return wifi_devices
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,7 +48,7 @@ def mock_coordinator_data():
                 "ip": "192.168.1.100",
                 "vendor": "Apple",
                 "device_type": "Mobile Device",
-                "vlan_id": 1,
+                "network_name": "lan",
             }
         ],
         "system_info": {

--- a/tests/test_vlan_from_openwrt.py
+++ b/tests/test_vlan_from_openwrt.py
@@ -1,0 +1,168 @@
+"""Tests for network detection from OpenWrt wireless status."""
+
+from unittest.mock import Mock
+
+from custom_components.wrtmanager.coordinator import WrtManagerCoordinator
+
+# ─── _build_interface_network_map tests ───
+
+
+def test_build_map_from_wireless_status():
+    """Test building interface-to-network map from real wireless status data."""
+    interfaces = {
+        "10.0.0.1": {
+            "radio0": {
+                "interfaces": [
+                    {
+                        "ifname": "phy0-ap0",
+                        "config": {"ssid": "MyWiFi", "network": ["lan"]},
+                    },
+                    {
+                        "ifname": "phy0-ap1",
+                        "config": {"ssid": "IoT", "network": ["iot"]},
+                    },
+                ],
+            },
+            "radio1": {
+                "interfaces": [
+                    {
+                        "ifname": "phy1-ap0",
+                        "config": {"ssid": "MyWiFi", "network": ["lan"]},
+                    },
+                ],
+            },
+            # Non-wireless interfaces should be skipped
+            "br-lan": {"up": True, "mtu": 1500},
+        },
+    }
+
+    result = WrtManagerCoordinator._build_interface_network_map(interfaces)
+
+    assert result == {
+        "10.0.0.1:phy0-ap0": "lan",
+        "10.0.0.1:phy0-ap1": "iot",
+        "10.0.0.1:phy1-ap0": "lan",
+    }
+
+
+def test_build_map_multiple_routers():
+    """Test mapping across multiple routers."""
+    interfaces = {
+        "10.0.0.1": {
+            "radio0": {
+                "interfaces": [
+                    {"ifname": "phy0-ap0", "config": {"network": ["lan"]}},
+                ],
+            },
+        },
+        "10.0.0.2": {
+            "radio0": {
+                "interfaces": [
+                    {"ifname": "phy0-ap0", "config": {"network": ["lan"]}},
+                    {"ifname": "phy0-ap1", "config": {"network": ["guest"]}},
+                ],
+            },
+        },
+    }
+
+    result = WrtManagerCoordinator._build_interface_network_map(interfaces)
+
+    assert result["10.0.0.1:phy0-ap0"] == "lan"
+    assert result["10.0.0.2:phy0-ap0"] == "lan"
+    assert result["10.0.0.2:phy0-ap1"] == "guest"
+
+
+def test_build_map_network_as_string():
+    """Test handling network as string instead of list."""
+    interfaces = {
+        "10.0.0.1": {
+            "radio0": {
+                "interfaces": [
+                    {"ifname": "phy0-ap0", "config": {"network": "lan"}},
+                ],
+            },
+        },
+    }
+
+    result = WrtManagerCoordinator._build_interface_network_map(interfaces)
+    assert result["10.0.0.1:phy0-ap0"] == "lan"
+
+
+def test_build_map_empty_interfaces():
+    """Test with no wireless data."""
+    result = WrtManagerCoordinator._build_interface_network_map({})
+    assert result == {}
+
+
+def test_build_map_skips_missing_ifname():
+    """Test that entries without ifname are skipped."""
+    interfaces = {
+        "10.0.0.1": {
+            "radio0": {
+                "interfaces": [
+                    {"config": {"network": ["lan"]}},  # No ifname
+                ],
+            },
+        },
+    }
+
+    result = WrtManagerCoordinator._build_interface_network_map(interfaces)
+    assert result == {}
+
+
+def test_build_map_skips_missing_network():
+    """Test that entries without network config are skipped."""
+    interfaces = {
+        "10.0.0.1": {
+            "radio0": {
+                "interfaces": [
+                    {"ifname": "phy0-ap0", "config": {"ssid": "test"}},  # No network
+                ],
+            },
+        },
+    }
+
+    result = WrtManagerCoordinator._build_interface_network_map(interfaces)
+    assert result == {}
+
+
+# ─── _correlate_device_data network enrichment tests ───
+
+
+def test_correlate_sets_network_name():
+    """Test that _correlate_device_data sets network_name from the map."""
+    coordinator = Mock()
+    coordinator.device_manager = Mock()
+    coordinator.device_manager.identify_device = Mock(return_value=None)
+
+    devices = [
+        {
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "interface": "phy0-ap0",
+            "router": "10.0.0.1",
+        }
+    ]
+    interface_map = {"10.0.0.1:phy0-ap0": "iot"}
+
+    result = WrtManagerCoordinator._correlate_device_data(coordinator, devices, {}, interface_map)
+
+    assert result[0]["network_name"] == "iot"
+
+
+def test_correlate_no_map_no_network_name():
+    """Test that network_name is not set when no map is provided."""
+    coordinator = Mock()
+    coordinator.device_manager = Mock()
+    coordinator.device_manager.identify_device = Mock(return_value=None)
+
+    devices = [
+        {
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "interface": "phy0-ap0",
+            "router": "10.0.0.1",
+        }
+    ]
+
+    result = WrtManagerCoordinator._correlate_device_data(coordinator, devices, {})
+
+    assert result[0].get("network_name") is None


### PR DESCRIPTION
## Summary

- Replaces the entire VLAN heuristic system with actual OpenWrt network names read from `network.wireless.status`
- Each device now shows its real network assignment (e.g. `lan`, `iot`, `guest`) instead of guessed VLAN IDs
- Removes the "Customize VLAN Names" config flow step (no longer needed)

## What was wrong

The old `_determine_vlan()` guessed VLAN IDs using a chain of unreliable heuristics:
- `ap1` interface → assumed VLAN 10
- `ap2` interface → assumed VLAN 100  
- IP third octet (e.g. `192.168.5.x`) → assumed VLAN 5
- Hardcoded keyword matching (`iot`, `guest` in interface names)

These produced wrong results for most networks.

## How it works now

1. OpenWrt's `network.wireless.status` already reports the network name for each wireless interface (e.g. `phy0-ap0` → `lan`, `phy0-ap1` → `iot`)
2. We already collect this data every poll cycle for SSID monitoring
3. New `_build_interface_network_map()` extracts a simple `{router:interface → network_name}` lookup
4. Each device gets enriched with its actual `network_name` attribute

## Changes

| File | Change |
|------|--------|
| `coordinator.py` | Add `_build_interface_network_map()`, remove `_determine_vlan()` and VLAN mapping |
| `binary_sensor.py` | Show `network` attribute instead of `vlan_id`/`vlan_name` |
| `sensor.py` | Group device counts by network name instead of VLAN ID |
| `const.py` | Remove `VLAN_NAMES`, `CONF_VLAN_NAMES`, `ATTR_VLAN_ID`; add `ATTR_NETWORK_NAME` |
| `config_flow.py` | Remove "Customize VLAN Names" option step |
| `translations/en.json` | Remove VLAN names form strings |
| Tests | 8 new tests, updated existing tests |

## Test plan

- [x] 191 tests passing (8 new + updated existing)
- [x] Pre-commit hooks pass
- [x] Manual test: devices show correct `network` attribute matching OpenWrt config
- [x] No more fake VLAN IDs (like "VLAN 238")

Closes #112