### PR TITLE
Fix: Use MAC-only unique IDs for presence sensors with auto-migration

### DIFF
--- a/custom_components/wrtmanager/binary_sensor.py
+++ b/custom_components/wrtmanager/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceEntry, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -55,17 +56,63 @@ async def async_setup_entry(
 
     entities = []
 
+    # Migrate old-format presence entity unique IDs to MAC-only format
+    entity_registry = er.async_get(hass)
+    migrated = 0
+    for entity in list(entity_registry.entities.values()):
+        if entity.platform != DOMAIN or not entity.unique_id.endswith("_presence"):
+            continue
+        # Old formats: wrtmanager_{router_ip}_{mac}_presence or wrtmanager_unknown_{mac}_presence
+        # New format: wrtmanager_{mac}_presence
+        parts = entity.unique_id.split("_")
+        if (
+            len(parts) > 8
+        ):  # Has router IP or "unknown" prefix beyond wrtmanager + 6 mac parts + presence
+            # Extract MAC from the end: last 7 parts are xx_xx_xx_xx_xx_xx_presence
+            mac_parts = parts[-7:-1]  # 6 hex pairs
+            new_unique_id = f"{DOMAIN}_{'_'.join(mac_parts)}_presence"
+            # Only migrate if the new unique ID isn't already taken
+            if not entity_registry.async_get_entity_id("binary_sensor", DOMAIN, new_unique_id):
+                entity_registry.async_update_entity(entity.entity_id, new_unique_id=new_unique_id)
+                migrated += 1
+            else:
+                # New format already exists, remove the old duplicate
+                entity_registry.async_remove(entity.entity_id)
+                migrated += 1
+    if migrated:
+        _LOGGER.info("Migrated %d presence sensors to MAC-only unique IDs", migrated)
+
     # Debug logging for available data
     _LOGGER.debug(
         "Binary sensor setup - coordinator data keys: %s",
         list(coordinator.data.keys()) if coordinator.data else "None",
     )
 
-    # Create binary sensors for device presence
+    # Create binary sensors for device presence (with dynamic updates)
+    created_macs: set[str] = set()
+
     for device in coordinator.data.get("devices", []):
         mac = device.get(ATTR_MAC)
-        if mac:
+        if mac and mac.upper() not in created_macs:
+            created_macs.add(mac.upper())
             entities.append(WrtDevicePresenceSensor(coordinator, mac, config_entry))
+
+    @callback
+    def _async_add_new_presence_sensors() -> None:
+        """Add presence sensors for newly discovered devices."""
+        if not coordinator.data or "devices" not in coordinator.data:
+            return
+        new_entities = []
+        for device in coordinator.data["devices"]:
+            mac = device.get(ATTR_MAC)
+            if mac and mac.upper() not in created_macs:
+                created_macs.add(mac.upper())
+                new_entities.append(WrtDevicePresenceSensor(coordinator, mac, config_entry))
+        if new_entities:
+            async_add_entities(new_entities)
+            _LOGGER.debug("Added %d new presence sensors", len(new_entities))
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_async_add_new_presence_sensors))
 
     # Create interface status binary sensors
     if coordinator.data and "interfaces" in coordinator.data:
@@ -641,16 +688,17 @@ class WrtDevicePresenceSensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self._mac = mac.upper()
         self._config_entry = config_entry
-        self._router_host = config_entry.data.get("host")
 
         # Get device info for initial setup
         device_data = self._get_device_data()
         device_name = self._get_device_name(device_data)
 
-        # Include router host in unique ID to avoid conflicts when same
-        # device connects to different routers
-        router_id = self._router_host.replace(".", "_") if self._router_host else "unknown"
-        self._attr_unique_id = f"{DOMAIN}_{router_id}_{mac.lower().replace(':', '_')}_presence"
+        # Get router host from device data for device_info grouping
+        self._router_host = device_data.get(ATTR_ROUTER) if device_data else None
+
+        # Use MAC-only unique ID — one presence sensor per device.
+        # Roaming is tracked via the primary_ap attribute, not separate entities.
+        self._attr_unique_id = f"{DOMAIN}_{mac.lower().replace(':', '_')}_presence"
         self._attr_name = f"{device_name} Presence"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 

--- a/tests/test_device_registry_fixes.py
+++ b/tests/test_device_registry_fixes.py
@@ -39,8 +39,8 @@ def mock_config_entry():
 class TestDeviceRegistryFixes:
     """Test device registry via_device fixes."""
 
-    def test_unique_id_includes_router_host(self, mock_coordinator, mock_config_entry):
-        """Test that unique IDs include router host to prevent collisions."""
+    def test_unique_id_uses_mac_only(self, mock_coordinator, mock_config_entry):
+        """Test that unique IDs use MAC only — one sensor per device."""
         with patch("custom_components.wrtmanager.binary_sensor.dr"):
             mock_hass = Mock()
 
@@ -51,12 +51,11 @@ class TestDeviceRegistryFixes:
             )
             sensor.hass = mock_hass
 
-            # Check that unique ID includes router host
-            expected_unique_id = "wrtmanager_192_168_1_1_2e_34_e7_d0_21_aa_presence"
+            expected_unique_id = "wrtmanager_2e_34_e7_d0_21_aa_presence"
             assert sensor.unique_id == expected_unique_id
 
-    def test_unique_id_different_routers(self, mock_coordinator):
-        """Test that same device on different routers gets different unique IDs."""
+    def test_unique_id_same_across_routers(self, mock_coordinator):
+        """Test that same device on different routers gets the same unique ID."""
         config_entry1 = Mock()
         config_entry1.data = {"host": "192.168.1.1"}
 
@@ -80,10 +79,8 @@ class TestDeviceRegistryFixes:
             )
             sensor2.hass = mock_hass
 
-            # Same MAC, different routers should have different unique IDs
-            assert sensor1.unique_id != sensor2.unique_id
-            assert "192_168_1_1" in sensor1.unique_id
-            assert "192_168_1_2" in sensor2.unique_id
+            # Same MAC should have same unique ID regardless of router
+            assert sensor1.unique_id == sensor2.unique_id
 
     def test_via_device_with_existing_router(self, mock_coordinator, mock_config_entry):
         """Test via_device is set when router device exists."""


### PR DESCRIPTION
## Summary
- Use MAC-only unique IDs for presence sensors (one sensor per device)
- Roaming tracked via `primary_ap` attribute, not separate entities per router
- Add dynamic presence sensor creation via coordinator listener so new devices appear without reload
- Auto-migrate old-format entities on startup (rename or deduplicate)

The unique ID format changed in v0.8.3 (#104) from `wrtmanager_{host}_{mac}_presence` to include router IP, but `config_entry.data.get("host")` was always `None` (host is nested under `routers`), so all entities got `wrtmanager_unknown_{mac}_presence`. This caused stale entities to accumulate and devices to not appear in dashboards.

Fixes #118

## Test plan
- [x] All 191 tests pass
- [ ] Clean install: all devices get presence sensors matching coordinator count
- [ ] Upgrade from v0.8.3: old entities auto-migrated to MAC-only format
- [ ] Devices roaming between APs maintain single presence sensor
- [ ] New devices appearing after setup get sensors automatically (no reload needed)