### PR TITLE
Fix: Card device lookup prefers WrtManager device when duplicates exist

### DIFF
--- a/custom_components/wrtmanager/www/wrtmanager-cards.js
+++ b/custom_components/wrtmanager/www/wrtmanager-cards.js
@@ -79,15 +79,18 @@ const WrtManagerMixin = (superClass) =>
     findDeviceByMac(mac) {
       if (!mac || mac === "-" || !this.hass?.devices) return null;
       const macUpper = mac.toUpperCase();
+      let fallback = null;
       for (const device of Object.values(this.hass.devices)) {
         if (!device.connections) continue;
         for (const [type, value] of device.connections) {
           if (type === "mac" && value.toUpperCase() === macUpper) {
-            return device;
+            // Prefer the device that has wrtmanager identifiers
+            if (device.identifiers?.some(([d]) => d === "wrtmanager")) return device;
+            if (!fallback) fallback = device;
           }
         }
       }
-      return null;
+      return fallback;
     }
 
     findRouterDevice(routerIp) {


### PR DESCRIPTION
## Summary
- Fix `findDeviceByMac()` in cards to prefer the device with wrtmanager identifiers when multiple HA devices share the same MAC connection
- This fixes the disconnect icon not showing and clicking navigating to the wrong device page

HA sometimes doesn't merge devices that share the same MAC connection across integrations (e.g., Shelly + WrtManager), resulting in duplicate device entries. The card now correctly picks the WrtManager device.

## Test plan
- [ ] Click device in network devices card navigates to correct device page
- [ ] Disconnect icon shows for devices that have a disconnect button entity