### PR TITLE
Fix Lovelace resource registration race condition on HA startup

### DIFF
--- a/custom_components/wrtmanager/__init__.py
+++ b/custom_components/wrtmanager/__init__.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -72,22 +72,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Register custom Lovelace cards (only once across all config entries)
     if not hass.data.get(f"{DOMAIN}_cards_registered"):
+        hass.data[f"{DOMAIN}_cards_registered"] = True
         try:
             await hass.http.async_register_static_paths(
                 [StaticPathConfig(CARDS_URL, str(CARDS_PATH), cache_headers=False)]
             )
-            hass.data[f"{DOMAIN}_cards_registered"] = True
-
-            resources = hass.data["lovelace"].resources
-            if not any(r.get("url", "").startswith(CARDS_URL) for r in resources.async_items()):
-                await resources.async_create_item({"res_type": "module", "url": CARDS_RESOURCE_URL})
-                _LOGGER.info("Registered WrtManager Lovelace cards v%s", CARDS_VERSION)
         except Exception:
             _LOGGER.info(
-                "Could not auto-register Lovelace cards. "
+                "Could not register Lovelace card path. "
                 "Add '%s' as a JS module resource manually.",
                 CARDS_URL,
             )
+
+        async def _register_cards(_event: Event | None = None) -> None:
+            try:
+                resources = hass.data["lovelace"].resources
+                if not any(r.get("url", "").startswith(CARDS_URL) for r in resources.async_items()):
+                    await resources.async_create_item(
+                        {"res_type": "module", "url": CARDS_RESOURCE_URL}
+                    )
+                    _LOGGER.info("Registered WrtManager Lovelace cards v%s", CARDS_VERSION)
+            except Exception:
+                _LOGGER.info(
+                    "Could not auto-register Lovelace cards. "
+                    "Add '%s' as a JS module resource manually.",
+                    CARDS_URL,
+                )
+
+        if hass.is_running:
+            await _register_cards()
+        else:
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _register_cards)
 
     # Forward the setup to the sensor platform
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -105,6 +120,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         await coordinator.async_shutdown()
         hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            hass.data.pop(f"{DOMAIN}_cards_registered", None)
 
     return unload_ok
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,24 +1,205 @@
 """Tests for the WrtManager integration __init__ module."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.wrtmanager import async_unload_entry
+from custom_components.wrtmanager import async_setup_entry, async_unload_entry
 from custom_components.wrtmanager.const import CONF_ROUTERS, DOMAIN
+
+
+def _make_hass(is_running=True):
+    """Create a mock hass object suitable for testing async_setup_entry."""
+    mock_hass = Mock()
+    mock_hass.data = {}
+    mock_hass.is_running = is_running
+    mock_hass.config_entries = Mock()
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    mock_hass.http = Mock()
+    mock_hass.http.async_register_static_paths = AsyncMock()
+    mock_hass.bus = Mock()
+    mock_hass.bus.async_listen_once = Mock()
+
+    resources_mock = Mock()
+    resources_mock.async_items = Mock(return_value=[])
+    resources_mock.async_create_item = AsyncMock()
+    lovelace_mock = Mock()
+    lovelace_mock.resources = resources_mock
+    mock_hass.data["lovelace"] = lovelace_mock
+
+    return mock_hass
+
+
+def _make_entry(entry_id="test_entry"):
+    """Create a mock config entry."""
+    from homeassistant.config_entries import ConfigEntryState
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ROUTERS: [
+                {
+                    CONF_HOST: "192.168.1.1",
+                    CONF_NAME: "Test Router",
+                    CONF_USERNAME: "test",
+                    CONF_PASSWORD: "test",
+                }
+            ]
+        },
+        entry_id=entry_id,
+    )
+    # Set state so setup uses regular refresh path
+    entry._state = ConfigEntryState.LOADED
+    return entry
+
+
+def _make_coordinator():
+    mock_coordinator = Mock()
+    mock_coordinator.last_update_success = True
+    mock_coordinator.async_refresh = AsyncMock()
+    mock_coordinator.async_shutdown = AsyncMock()
+    return mock_coordinator
+
+
+@pytest.mark.asyncio
+async def test_deferred_registration_when_ha_not_running():
+    """async_listen_once is called (not async_create_item) when HA hasn't started."""
+    mock_hass = _make_hass(is_running=False)
+    entry = _make_entry()
+    coordinator = _make_coordinator()
+
+    with patch("custom_components.wrtmanager.WrtManagerCoordinator", return_value=coordinator):
+        result = await async_setup_entry(mock_hass, entry)
+
+    assert result is True
+    # Static path registered immediately
+    mock_hass.http.async_register_static_paths.assert_called_once()
+    # Listener registered for deferred resource write
+    mock_hass.bus.async_listen_once.assert_called_once()
+    event_name, callback = mock_hass.bus.async_listen_once.call_args[0]
+    from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+
+    assert event_name == EVENT_HOMEASSISTANT_STARTED
+    # Resource not created yet
+    mock_hass.data["lovelace"].resources.async_create_item.assert_not_called()
+
+    # Simulate HA started event firing
+    await callback(None)
+    mock_hass.data["lovelace"].resources.async_create_item.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_immediate_registration_when_ha_running():
+    """async_create_item is called immediately when HA is already running (reload)."""
+    mock_hass = _make_hass(is_running=True)
+    entry = _make_entry()
+    coordinator = _make_coordinator()
+
+    with patch("custom_components.wrtmanager.WrtManagerCoordinator", return_value=coordinator):
+        result = await async_setup_entry(mock_hass, entry)
+
+    assert result is True
+    mock_hass.data["lovelace"].resources.async_create_item.assert_called_once()
+    mock_hass.bus.async_listen_once.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guard_prevents_double_registration():
+    """Guard flag prevents double registration when two config entries load."""
+    mock_hass = _make_hass(is_running=True)
+    entry1 = _make_entry("entry1")
+    entry2 = _make_entry("entry2")
+    coordinator1 = _make_coordinator()
+    coordinator2 = _make_coordinator()
+
+    with patch(
+        "custom_components.wrtmanager.WrtManagerCoordinator",
+        side_effect=[coordinator1, coordinator2],
+    ):
+        await async_setup_entry(mock_hass, entry1)
+        await async_setup_entry(mock_hass, entry2)
+
+    mock_hass.http.async_register_static_paths.assert_called_once()
+    mock_hass.data["lovelace"].resources.async_create_item.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_guard_cleared_after_all_entries_unloaded():
+    """Guard is cleared only when the last entry is unloaded; re-registration works."""
+    mock_hass = _make_hass(is_running=True)
+    entry1 = _make_entry("entry1")
+    entry2 = _make_entry("entry2")
+    coordinator1 = _make_coordinator()
+    coordinator2 = _make_coordinator()
+
+    with patch(
+        "custom_components.wrtmanager.WrtManagerCoordinator",
+        side_effect=[coordinator1, coordinator2],
+    ):
+        await async_setup_entry(mock_hass, entry1)
+        await async_setup_entry(mock_hass, entry2)
+
+    # Unload first entry — guard should still be set
+    await async_unload_entry(mock_hass, entry1)
+    assert f"{DOMAIN}_cards_registered" in mock_hass.data
+
+    # Unload second entry — guard should be cleared
+    await async_unload_entry(mock_hass, entry2)
+    assert f"{DOMAIN}_cards_registered" not in mock_hass.data
+
+    # Re-setup should re-register
+    entry3 = _make_entry("entry3")
+    coordinator3 = _make_coordinator()
+    with patch("custom_components.wrtmanager.WrtManagerCoordinator", return_value=coordinator3):
+        await async_setup_entry(mock_hass, entry3)
+
+    assert mock_hass.data["lovelace"].resources.async_create_item.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_already_registered_resource_is_skipped():
+    """async_create_item is not called if the resource URL is already present."""
+    from custom_components.wrtmanager import CARDS_RESOURCE_URL
+
+    mock_hass = _make_hass(is_running=True)
+    mock_hass.data["lovelace"].resources.async_items = Mock(
+        return_value=[{"res_type": "module", "url": CARDS_RESOURCE_URL}]
+    )
+    entry = _make_entry()
+    coordinator = _make_coordinator()
+
+    with patch("custom_components.wrtmanager.WrtManagerCoordinator", return_value=coordinator):
+        await async_setup_entry(mock_hass, entry)
+
+    mock_hass.data["lovelace"].resources.async_create_item.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_exception_during_resource_write_is_swallowed():
+    """Exception in async_create_item is caught; setup still returns True."""
+    mock_hass = _make_hass(is_running=True)
+    mock_hass.data["lovelace"].resources.async_create_item = AsyncMock(
+        side_effect=Exception("boom")
+    )
+    entry = _make_entry()
+    coordinator = _make_coordinator()
+
+    with patch("custom_components.wrtmanager.WrtManagerCoordinator", return_value=coordinator):
+        result = await async_setup_entry(mock_hass, entry)
+
+    assert result is True
 
 
 @pytest.mark.asyncio
 async def test_async_unload_entry_calls_shutdown():
     """Test that async_unload_entry calls coordinator.async_shutdown()."""
-    # Create a mock hass object
     mock_hass = Mock()
     mock_hass.data = {DOMAIN: {}}
     mock_hass.config_entries = Mock()
 
-    # Create a mock config entry
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -34,38 +215,26 @@ async def test_async_unload_entry_calls_shutdown():
         entry_id="test_entry",
     )
 
-    # Create a mock coordinator with async_shutdown method
     mock_coordinator = Mock()
     mock_coordinator.async_shutdown = AsyncMock()
 
-    # Setup hass data
     mock_hass.data[DOMAIN][config_entry.entry_id] = mock_coordinator
-
-    # Mock the async_unload_platforms to return True
     mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
 
-    # Call async_unload_entry
     result = await async_unload_entry(mock_hass, config_entry)
 
-    # Assert that the function returned True
     assert result is True
-
-    # Assert that coordinator.async_shutdown was called
     mock_coordinator.async_shutdown.assert_called_once()
-
-    # Assert that the coordinator was removed from hass.data
     assert config_entry.entry_id not in mock_hass.data[DOMAIN]
 
 
 @pytest.mark.asyncio
 async def test_async_unload_entry_shutdown_not_called_on_failure():
     """Test that async_shutdown is not called if platform unload fails."""
-    # Create a mock hass object
     mock_hass = Mock()
     mock_hass.data = {DOMAIN: {}}
     mock_hass.config_entries = Mock()
 
-    # Create a mock config entry
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -81,24 +250,14 @@ async def test_async_unload_entry_shutdown_not_called_on_failure():
         entry_id="test_entry",
     )
 
-    # Create a mock coordinator with async_shutdown method
     mock_coordinator = Mock()
     mock_coordinator.async_shutdown = AsyncMock()
 
-    # Setup hass data
     mock_hass.data[DOMAIN][config_entry.entry_id] = mock_coordinator
-
-    # Mock the async_unload_platforms to return False (failure)
     mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
 
-    # Call async_unload_entry
     result = await async_unload_entry(mock_hass, config_entry)
 
-    # Assert that the function returned False
     assert result is False
-
-    # Assert that coordinator.async_shutdown was NOT called
     mock_coordinator.async_shutdown.assert_not_called()
-
-    # Assert that the coordinator was NOT removed from hass.data
     assert config_entry.entry_id in mock_hass.data[DOMAIN]


### PR DESCRIPTION
Fixes #156

## Changes
 custom_components/wrtmanager/__init__.py |  35 +++--
 tests/test_init.py                       | 211 +++++++++++++++++++++++++++----
 2 files changed, 211 insertions(+), 35 deletions(-)


## Test plan
- Unit tests: `PYTHONPATH=. .venv/bin/python -m pytest tests/ -v`
- Browser tests: screenshots in `.test-screenshots/`
